### PR TITLE
Update README.md - Change version package.

### DIFF
--- a/README.md
+++ b/README.md
@@ -24,7 +24,7 @@ Some behaviors (translatable, timestampable, softDeletable, blameable, geocodabl
 Make sure to activate them by reading the [Subscribers](#subscribers) section.
 
 ##Installation
-```composer require knplabs/doctrine-behaviors:~1.1```
+```composer require knplabs/doctrine-behaviors:dev-master```
 
 <a name="subscribers" id="subscribers"></a>
 ## Subscribers


### PR DESCRIPTION
"Recommended way" for including subscribers in Symfony 2 not works.

In README.md in part "Installation" version of package is incorrect.
The directory "src/Bundle" is not exists in version 1.1
